### PR TITLE
Add Qiniu Cloud Storage plugin

### DIFF
--- a/plugins/qiniu_storage/include/functions.inc.php
+++ b/plugins/qiniu_storage/include/functions.inc.php
@@ -1,0 +1,57 @@
+<?php
+if (!defined('PHPWG_ROOT_PATH')) die('Hacking attempt!');
+
+function qiniu_storage_get_conf()
+{
+  global $conf;
+  if (!isset($conf['qiniu_storage']))
+    return null;
+  if (is_string($conf['qiniu_storage']))
+    $conf['qiniu_storage'] = unserialize($conf['qiniu_storage']);
+  return $conf['qiniu_storage'];
+}
+
+function qiniu_storage_upload($image_infos)
+{
+  $config = qiniu_storage_get_conf();
+  if (empty($config) || empty($config['access_key']) || empty($config['bucket']))
+    return;
+
+  $path = PHPWG_ROOT_PATH . $image_infos['path'];
+  qiniu_storage_send_file($path, $image_infos['md5sum'], $config);
+}
+
+function qiniu_storage_send_file($file, $key, $config)
+{
+  $deadline = time() + 3600;
+  $policy = json_encode(array('scope'=>$config['bucket'].':'.$key, 'deadline'=>$deadline));
+  $encoded = str_replace(array('+','/'), array('-','_'), base64_encode($policy));
+  $sign = hash_hmac('sha1', $encoded, $config['secret_key'], true);
+  $encoded_sign = str_replace(array('+','/'), array('-','_'), base64_encode($sign));
+  $token = $config['access_key'].':'.$encoded_sign.':'.$encoded;
+
+  $ch = curl_init('https://upload.qiniup.com');
+  $post = array('token'=>$token, 'key'=>$key, 'file'=>new CURLFile($file));
+  curl_setopt($ch, CURLOPT_POST, true);
+  curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  curl_exec($ch);
+  curl_close($ch);
+}
+
+function qiniu_storage_src_url($url, $src_image)
+{
+  $config = qiniu_storage_get_conf();
+  if (empty($config) || empty($config['domain']))
+    return $url;
+  return 'https://'.$config['domain'].'/'.$src_image->rel_path;
+}
+
+function qiniu_storage_derivative_url($url, $params, $src_image, $rel_url)
+{
+  $config = qiniu_storage_get_conf();
+  if (empty($config) || empty($config['domain']))
+    return $url;
+  return 'https://'.$config['domain'].'/'.$rel_url;
+}
+?>

--- a/plugins/qiniu_storage/index.php
+++ b/plugins/qiniu_storage/index.php
@@ -1,0 +1,3 @@
+<?php
+// Silence is golden.
+?>

--- a/plugins/qiniu_storage/main.inc.php
+++ b/plugins/qiniu_storage/main.inc.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Plugin Name: Qiniu Cloud Storage
+Version: 1.0.0
+Description: Store uploaded photos in Qiniu Cloud Storage and serve them from Qiniu.
+Has Settings: True
+*/
+
+if (!defined('PHPWG_ROOT_PATH'))
+  die('Hacking attempt!');
+
+define('QINIU_STORAGE_DIR', basename(dirname(__FILE__)));
+include_once(PHPWG_PLUGINS_PATH . QINIU_STORAGE_DIR . '/include/functions.inc.php');
+
+add_event_handler('loc_end_add_uploaded_file', 'qiniu_storage_upload', EVENT_HANDLER_PRIORITY_NEUTRAL, 1);
+add_event_handler('get_src_image_url', 'qiniu_storage_src_url', EVENT_HANDLER_PRIORITY_NEUTRAL, 2);
+add_event_handler('get_derivative_url', 'qiniu_storage_derivative_url', EVENT_HANDLER_PRIORITY_NEUTRAL, 4);
+?>

--- a/plugins/qiniu_storage/maintain.class.php
+++ b/plugins/qiniu_storage/maintain.class.php
@@ -1,0 +1,26 @@
+<?php
+if (!defined('PHPWG_ROOT_PATH')) die('Hacking attempt!');
+
+class qiniu_storage_maintain extends PluginMaintain
+{
+  function install($plugin_version, &$errors=array())
+  {
+    global $conf;
+    if (!isset($conf['qiniu_storage']))
+    {
+      $config = array(
+        'access_key' => '',
+        'secret_key' => '',
+        'bucket'     => '',
+        'domain'     => ''
+      );
+      conf_update_param('qiniu_storage', serialize($config));
+    }
+  }
+
+  function uninstall()
+  {
+    conf_delete_param('qiniu_storage');
+  }
+}
+?>


### PR DESCRIPTION
## Summary
- implement `qiniu_storage` plugin to upload images to Qiniu and rewrite URLs

## Testing
- `git log -1 --stat`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef6406948328a31e802a860e9acf